### PR TITLE
Fix formatting / spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ See [LICENSE](LICENSE) for more information.
 
 See [SECURITY](SECURITY.md) for more
 information.
+
 ---
 *Note that due to an AWS limitation the agent image is also uploaded and then sourced from AWS ECR when executed on
 Lambda.


### PR DESCRIPTION
Lack of spacing was making text look like a header: 
<img width="834" alt="Screenshot 2023-12-18 at 3 10 56 PM" src="https://github.com/monte-carlo-data/terraform-aws-mcd-agent/assets/56234509/d122ac39-edfe-41f4-b470-7cce89631991">
