### PR TITLE
Remove provider definition and add support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ Lambda, along with storage, roles etc.
 See [here](https://docs.getmontecarlo.com/docs/platform-architecture) for architecture details and alternative
 deployment options.
 
-## Prerequisites
-
-- [Terraform](https://developer.hashicorp.com/terraform/downloads) (>= 1.3)
-- [AWS CLI](https://aws.amazon.com/cli/).
-  [Authentication reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration)
 
 ## Usage
 
@@ -41,25 +36,74 @@ After which you must register your agent with Monte Carlo. See
 [here](https://docs.getmontecarlo.com/docs/create-and-register-an-aws-agent) for more details, options, and
 documentation.
 
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.40.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.mcd_agent_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.mcd_agent_service_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.mcd_agent_service_invocation_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.mcd_agent_service_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_lambda_info_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_lambda_logs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_lambda_stop_query_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_lambda_update_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_repo_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.mcd_agent_service_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.mcd_agent_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.mcd_agent_service_with_remote_upgrade_support](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_s3_bucket.mcd_agent_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_cors_configuration.mcd_agent_store_cors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.mcd_agent_store_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.mcd_agent_store_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.mcd_agent_store_block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.mcd_agent_store_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_security_group.mcd_agent_vpc_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [random_id.mcd_agent_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_subnet.first_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+
 ## Inputs
 
-| **Name**          | **Description**                                                                                                                                                                                                                                                                                                                                                                                                                             | **Type**     | **Default**                                           |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|-------------------------------------------------------|
-| image             | URI of the Agent container image (ECR Repo). Note that the region is automatically derived from the region variable.                                                                                                                                                                                                                                                                                                                        | string       | 752656882040.dkr.ecr.*.amazonaws.com/mcd-agent:latest |
-| cloud_account_id  | Select the Monte Carlo account your collection service is hosted in. This can be found in the '[settings/integrations/collectors](https://getmontecarlo.com/settings/integrations/collectors)' tab on the UI or via the '[montecarlo collectors list](https://clidocs.getmontecarlo.com/#montecarlo-collectors-list)' command on the CLI                                                                                                    | string       | 190812797848                                          |
-| private_subnets   | Optionally connect the agent to a VPC by specifying at least two private subnet IDs in that VPC.                                                                                                                                                                                                                                                                                                                                            | list(string) | []                                                    |
-| region            | The AWS region to deploy the agent into.                                                                                                                                                                                                                                                                                                                                                                                                    | string       | us-east-1                                             |
-| remote_upgradable | Allow the agent image and configuration to be remotely upgraded by Monte Carlo. Note that this sets a lifecycle to ignore any changes in Terraform to the image used after the initial deployment. If not set to 'true' you will be responsible for upgrading the image (e.g. specifying a new tag) for any bug fixes and improvements. Changing this value after initial deployment might replace your agent and require (re)registration. | bool         | true                                                  |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_account_id"></a> [cloud\_account\_id](#input\_cloud\_account\_id) | Select the Monte Carlo account your collection service is hosted in.<br><br>    This can be found in the 'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI | `string` | `"190812797848"` | no |
+| <a name="input_image"></a> [image](#input\_image) | URI of the Agent container image (ECR Repo). Note that the region is automatically derived from the region variable. | `string` | `"752656882040.dkr.ecr.*.amazonaws.com/mcd-agent:latest"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Optionally connect the agent to a VPC by specifying at least two private subnet IDs in that VPC. | `list(string)` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region to deploy the agent into. | `string` | `"us-east-1"` | no |
+| <a name="input_remote_upgradable"></a> [remote\_upgradable](#input\_remote\_upgradable) | Allow the agent image and configuration to be remotely upgraded by Monte Carlo.<br><br>    Note that this sets a lifecycle to ignore any changes in Terraform to the image used after the initial deployment.<br><br>    If not set to 'true' you will be responsible for upgrading the image (e.g. specifying a new tag) for any bug fixes and improvements.<br><br>    Changing this value after initial deployment might replace your agent and require (re)registration. | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
-| **Name**                           | **Description**                                        |
-|------------------------------------|--------------------------------------------------------|
-| mcd_agent_function_arn             | Agent Function ARN. To be used in registering.         |
-| mcd_agent_invoker_role_arn         | Assumable role ARN. To be used in registering.         |
-| mcd_agent_invoker_role_external_id | Assumable role External ID. To be used in registering. |
-| mcd_agent_security_group_name      | Security group ID.                                     |
-| mcd_agent_storage_bucket_arn       | Storage bucket ARN.                                    |
+| Name | Description |
+|------|-------------|
+| <a name="output_mcd_agent_function_arn"></a> [mcd\_agent\_function\_arn](#output\_mcd\_agent\_function\_arn) | Agent Function ARN. To be used in registering. |
+| <a name="output_mcd_agent_invoker_role_arn"></a> [mcd\_agent\_invoker\_role\_arn](#output\_mcd\_agent\_invoker\_role\_arn) | Assumable role ARN. To be used in registering. |
+| <a name="output_mcd_agent_invoker_role_external_id"></a> [mcd\_agent\_invoker\_role\_external\_id](#output\_mcd\_agent\_invoker\_role\_external\_id) | Assumable role External ID. To be used in registering. |
+| <a name="output_mcd_agent_security_group_name"></a> [mcd\_agent\_security\_group\_name](#output\_mcd\_agent\_security\_group\_name) | Security group ID. |
+| <a name="output_mcd_agent_storage_bucket_arn"></a> [mcd\_agent\_storage\_bucket\_arn](#output\_mcd\_agent\_storage\_bucket\_arn) | Storage bucket ARN. |
+<!-- END_TF_DOCS -->
 
 ## Releases and Development
 

--- a/provider.tf
+++ b/provider.tf
@@ -1,9 +1,0 @@
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = {
-      "mcd-agent-service-name"    = lower(local.mcd_agent_service_name)
-      "mcd-agent-deployment-type" = lower(local.mcd_agent_deployment_type)
-    }
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "remote_upgradable" {
   type        = bool
   default     = true
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
The scope of this contribution is to make this module more flexible and follow best practices according to official Terraform documentation.

Changes:

- Adding `var.tags` to allow users adding their own set of tags to the resources created by this module;
- remove `provider` definition (provider.tf) as it's not recommended for a child module to define the provider block (especially when `assume_role` block is used in the root module provider definition where this module is being initiated) [1]
- generate the docs using `terraform docs` (`terraform-docs markdown table --output-file README.md --output-mode inject .`) [2]


[1] https://developer.hashicorp.com/terraform/language/modules/develop/providers
[2] https://github.com/terraform-docs/terraform-docs