### PR TITLE
MES-146 Update agent template for CaaS migration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
   account_id                  = data.aws_caller_identity.current.account_id
   partition_id                = data.aws_partition.current.id
   connect_to_vpc              = length(var.private_subnets) >= 2 ? true : false
-  skip_cloud_account_policy   = contains(["N/A", "590183797493"], var.cloud_account_id)
+  skip_cloud_account_policy   = contains(["590183797493"], var.cloud_account_id)
   invocation_role_source_arns = local.skip_cloud_account_policy ? ["arn:aws:iam::590183797493:root"] : ["arn:aws:iam::${var.cloud_account_id}:root", "arn:aws:iam::590183797493:root"]
 
   # Data store properties

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,10 @@ locals {
   mcd_agent_deployment_type = "TERRAFORM"
 
   # Deployment properties
-  account_id     = data.aws_caller_identity.current.account_id
-  partition_id   = data.aws_partition.current.id
-  connect_to_vpc = length(var.private_subnets) >= 2 ? true : false
-  skip_cloud_account_policy = contains(["N/A", "590183797493"], var.cloud_account_id)
+  account_id                  = data.aws_caller_identity.current.account_id
+  partition_id                = data.aws_partition.current.id
+  connect_to_vpc              = length(var.private_subnets) >= 2 ? true : false
+  skip_cloud_account_policy   = contains(["N/A", "590183797493"], var.cloud_account_id)
   invocation_role_source_arns = local.skip_cloud_account_policy ? ["arn:aws:iam::590183797493:root"] : ["arn:aws:iam::${var.cloud_account_id}:root", "arn:aws:iam::590183797493:root"]
 
   # Data store properties

--- a/variables.tf
+++ b/variables.tf
@@ -6,13 +6,16 @@ variable "image" {
 
 variable "cloud_account_id" {
   description = <<EOF
-    [Deprecated] For updates use the previous value, for new deployments use N/A.
+    The service that invokes the agent is being migrated to the AWS Account with ID: 590183797493.
+    For accounts created after April 24th, 2024 select 590183797493, for previously created
+    accounts select the Monte Carlo account your collection service is hosted in.
+    This can be found in the 'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI.
   EOF
   type        = string
   default     = "190812797848"
   validation {
-    condition     = contains(["N/A", "190812797848", "799135046351", "682816785079", "637423407294", "590183797493"], var.cloud_account_id)
-    error_message = "Valid value is one of the following: N/A, 190812797848, 799135046351, 682816785079, 637423407294, 590183797493."
+    condition     = contains(["190812797848", "799135046351", "682816785079", "637423407294", "590183797493"], var.cloud_account_id)
+    error_message = "Valid value is one of the following: 190812797848, 799135046351, 682816785079, 637423407294, 590183797493."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,15 +6,13 @@ variable "image" {
 
 variable "cloud_account_id" {
   description = <<EOF
-    Select the Monte Carlo account your collection service is hosted in.
-
-    This can be found in the 'settings/integrations/collectors' tab on the UI or via the 'montecarlo collectors list' command on the CLI
+    [Deprecated] For updates use the previous value, for new deployments use N/A.
   EOF
   type        = string
   default     = "190812797848"
   validation {
-    condition     = contains(["190812797848", "799135046351", "682816785079", "637423407294", "590183797493"], var.cloud_account_id)
-    error_message = "Valid value is one of the following: 190812797848, 799135046351, 682816785079, 637423407294, 590183797493."
+    condition     = contains(["N/A", "190812797848", "799135046351", "682816785079", "637423407294", "590183797493"], var.cloud_account_id)
+    error_message = "Valid value is one of the following: N/A, 190812797848, 799135046351, 682816785079, 637423407294, 590183797493."
   }
 }
 


### PR DESCRIPTION
- This PR updates the policy for the invocation role defined by the agent to accept invocations from the new CaaS account: `590183797493`.
- For the migration process, we'll need the agent to accept invocations from both accounts, first from the account hosting the DC now (before the migration) and then from the CaaS account (once the migration is ready).
