### PR TITLE
Removing provider definition

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,9 +1,0 @@
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = {
-      "mcd-agent-service-name"    = lower(local.mcd_agent_service_name)
-      "mcd-agent-deployment-type" = lower(local.mcd_agent_deployment_type)
-    }
-  }
-}

--- a/tagging.tf
+++ b/tagging.tf
@@ -1,0 +1,6 @@
+locals {
+  common_tags = {
+    "mcd-agent-service-name"    = lower(local.mcd_agent_service_name)
+    "mcd-agent-deployment-type" = lower(local.mcd_agent_deployment_type)
+  }
+}


### PR DESCRIPTION
The current module design uses a module declared provider which prevents its use in a scenario where the module is being deployed by a larger project/parent module especially when that parent module leverages an AWS Assumed Role deployment for the AWS provider. Specifically in HCP Terraform when using an assume_role_arn for the parent module, it does not get passed to this module as a submodule and because this module specifies it's own provider configuration, you cannot override its provider configuration. This is a blocker for our deployment. Invocation of this module should delegate the decision on AWS credential sourcing methods (assumed role, cli profile, etc.) to the calling parent module. 